### PR TITLE
Add predictive engine and integrate warlock

### DIFF
--- a/TacoRot.toc
+++ b/TacoRot.toc
@@ -9,6 +9,8 @@ embeds.xml
 Bindings.xml
 Compat-335.lua
 core.lua
+prediction_engine.lua
+core_prediction_integration.lua
 ui_safe_override.lua
 ui.lua
 options.lua

--- a/core_prediction_integration.lua
+++ b/core_prediction_integration.lua
@@ -1,0 +1,351 @@
+local TR = _G.TacoRot
+
+-- ================= Enhanced Core Integration =================
+
+-- Default configuration for prediction system
+local predictionDefaults = {
+    profile = {
+        prediction = {
+            enabled = true,
+            maxDepth = 6,              -- How many spells to predict ahead
+            updateInterval = 0.1,       -- Base update interval (seconds)
+            adaptiveInterval = true,    -- Adjust interval based on combat state
+            combatInterval = 0.05,      -- Interval during active combat
+            idleInterval = 0.5,         -- Interval when idle
+            useSimulation = true,       -- Enable state simulation
+            debugMode = false,          -- Show prediction debug info
+            cacheSize = 100,           -- Max cached predictions
+        }
+    }
+}
+
+-- Merge prediction defaults with existing defaults
+if TR.defaults then
+    for k, v in pairs(predictionDefaults.profile) do
+        TR.defaults.profile[k] = v
+    end
+else
+    TR.defaults = predictionDefaults
+end
+
+-- ================= Enhanced OnEnable =================
+
+-- Store original OnEnable if it exists
+TR._originalOnEnable = TR._originalOnEnable or TR.OnEnable
+
+function TR:OnEnable()
+    -- Call original OnEnable
+    if self._originalOnEnable then
+        self._originalOnEnable(self)
+    end
+
+    -- Initialize prediction system
+    if self.db.profile.prediction.enabled then
+        self:InitializePredictionSystem()
+    end
+end
+
+function TR:InitializePredictionSystem()
+    -- Initialize prediction state
+    self.PredictionCache = {}
+    self.LastGameState = {}
+    self.PredictionStats = {
+        updates = 0,
+        cacheHits = 0,
+        cacheMisses = 0,
+        avgUpdateTime = 0,
+    }
+
+    -- Register events for real-time updates
+    if self.RegisterPredictionEvents then
+        self:RegisterPredictionEvents()
+    end
+
+    -- Start performance monitoring
+    self:ScheduleRepeatingTimer("CleanupPredictionCache", 30) -- Cleanup every 30 seconds
+
+    self:Print("Enhanced prediction system initialized")
+end
+
+-- ================= Performance Monitoring =================
+
+function TR:CleanupPredictionCache()
+    local cfg = self.db.profile.prediction
+    local maxSize = cfg.cacheSize or 100
+
+    -- Clear old cache entries
+    local count = 0
+    for k, v in pairs(self.PredictionCache) do
+        count = count + 1
+    end
+
+    if count > maxSize then
+        self.PredictionCache = {}
+        if cfg.debugMode then
+            self:Print("Prediction cache cleared (" .. count .. " entries)")
+        end
+    end
+end
+
+function TR:GetPredictionStats()
+    if not self.PredictionStats then return "Prediction system not initialized" end
+
+    local stats = self.PredictionStats
+    return string.format(
+        "Prediction Stats - Updates: %d, Cache: %.1f%% hit rate, Avg: %.2fms", 
+        stats.updates,
+        stats.cacheHits / math.max(1, stats.cacheHits + stats.cacheMisses) * 100,
+        stats.avgUpdateTime * 1000
+    )
+end
+
+-- ================= Enhanced UpdateRotationDisplay =================
+
+-- Store original UpdateRotationDisplay
+TR._originalUpdateRotationDisplay = TR._originalUpdateRotationDisplay or TR.UpdateRotationDisplay
+
+function TR:UpdateRotationDisplay()
+    local cfg = self.db.profile.prediction
+
+    if cfg.enabled and cfg.useSimulation then
+        self:UpdatePredictiveRotationDisplay()
+    else
+        -- Fallback to original system
+        if self._originalUpdateRotationDisplay then
+            self._originalUpdateRotationDisplay(self)
+        end
+    end
+end
+
+function TR:UpdatePredictiveRotationDisplay()
+    local startTime = GetTime()
+
+    -- Update prediction stats
+    self.PredictionStats.updates = self.PredictionStats.updates + 1
+
+    -- Trigger current engine tick if available
+    local _, class = UnitClass("player")
+    if class then
+        local enhancedTickMethod = "EngineTick_" .. class .. "_Enhanced"
+        local normalTickMethod = "EngineTick_" .. class
+
+        if self[enhancedTickMethod] then
+            self[enhancedTickMethod](self)
+        elseif self[normalTickMethod] then
+            self[normalTickMethod](self)
+        end
+    end
+
+    -- Update performance stats
+    local endTime = GetTime()
+    local updateTime = endTime - startTime
+    local stats = self.PredictionStats
+    stats.avgUpdateTime = (stats.avgUpdateTime * 0.95) + (updateTime * 0.05) -- Rolling average
+end
+
+-- ================= Dynamic Timer System =================
+
+function TR:GetOptimalUpdateInterval()
+    local cfg = self.db.profile.prediction
+    if not cfg.adaptiveInterval then
+        return cfg.updateInterval or 0.1
+    end
+
+    local now = GetTime()
+    local timeSinceLastCast = now - (self.lastCastTime or 0)
+    local inCombat = UnitAffectingCombat("player")
+    local isCasting = UnitCastingInfo("player") ~= nil or UnitChannelInfo("player") ~= nil
+    local isMoving = GetUnitSpeed("player") > 0
+
+    -- High frequency during active gameplay
+    if isCasting or (inCombat and timeSinceLastCast < 2) then
+        return cfg.combatInterval or 0.05 -- 50ms
+    end
+
+    -- Medium frequency during combat
+    if inCombat or isMoving then
+        return cfg.updateInterval or 0.1 -- 100ms
+    end
+
+    -- Low frequency when idle
+    if timeSinceLastCast > 5 then
+        return cfg.idleInterval or 0.5 -- 500ms
+    end
+
+    return cfg.updateInterval or 0.1
+end
+
+-- Enhanced UpdatePredictionEngine
+TR.UpdatePredictionEngine = TR.GetOptimalUpdateInterval
+
+-- ================= Configuration Options =================
+
+-- Add to your options table (in options.lua)
+function TR:AddPredictionOptions(optionsTable)
+    if not optionsTable.args then optionsTable.args = {} end
+
+    optionsTable.args.prediction = {
+        type = "group",
+        name = "Prediction System",
+        order = 50,
+        args = {
+            enabled = {
+                type = "toggle",
+                name = "Enable Enhanced Prediction",
+                desc = "Use Hekili-style real-time prediction system",
+                order = 1,
+                get = function() return self.db.profile.prediction.enabled end,
+                set = function(_, v) 
+                    self.db.profile.prediction.enabled = v
+                    if v then
+                        self:InitializePredictionSystem()
+                    end
+                end,
+            },
+            maxDepth = {
+                type = "range",
+                name = "Prediction Depth",
+                desc = "How many spells to predict ahead (higher = more CPU usage)",
+                order = 2,
+                min = 3, max = 10, step = 1,
+                get = function() return self.db.profile.prediction.maxDepth end,
+                set = function(_, v) self.db.profile.prediction.maxDepth = v end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+            adaptiveInterval = {
+                type = "toggle",
+                name = "Adaptive Update Rate", 
+                desc = "Automatically adjust update frequency based on combat state",
+                order = 3,
+                get = function() return self.db.profile.prediction.adaptiveInterval end,
+                set = function(_, v) self.db.profile.prediction.adaptiveInterval = v end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+            updateInterval = {
+                type = "range",
+                name = "Base Update Interval",
+                desc = "Base update frequency in seconds (lower = more responsive, higher CPU)",
+                order = 4,
+                min = 0.05, max = 0.5, step = 0.01,
+                get = function() return self.db.profile.prediction.updateInterval end,
+                set = function(_, v) self.db.profile.prediction.updateInterval = v end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+            combatInterval = {
+                type = "range", 
+                name = "Combat Update Interval",
+                desc = "Update frequency during active combat",
+                order = 5,
+                min = 0.01, max = 0.2, step = 0.01,
+                get = function() return self.db.profile.prediction.combatInterval end,
+                set = function(_, v) self.db.profile.prediction.combatInterval = v end,
+                disabled = function() return not (self.db.profile.prediction.enabled and self.db.profile.prediction.adaptiveInterval) end,
+            },
+            debugMode = {
+                type = "toggle",
+                name = "Debug Mode",
+                desc = "Show prediction system debug information",
+                order = 10,
+                get = function() return self.db.profile.prediction.debugMode end,
+                set = function(_, v) self.db.profile.prediction.debugMode = v end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+            stats = {
+                type = "execute",
+                name = "Show Performance Stats",
+                desc = "Display prediction system performance statistics",
+                order = 20,
+                func = function() 
+                    self:Print(self:GetPredictionStats())
+                end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+            clearCache = {
+                type = "execute", 
+                name = "Clear Prediction Cache",
+                desc = "Manually clear the prediction cache",
+                order = 21,
+                func = function()
+                    self.PredictionCache = {}
+                    self:Print("Prediction cache cleared")
+                end,
+                disabled = function() return not self.db.profile.prediction.enabled end,
+            },
+        },
+    }
+end
+
+-- ================= Debug Functions =================
+
+function TR:DebugPrediction(message)
+    if self.db.profile.prediction.debugMode then
+        self:Print("[Prediction] " .. tostring(message))
+    end
+end
+
+function TR:DumpGameState()
+    if not self.CaptureGameState then 
+        self:Print("Prediction system not loaded")
+        return 
+    end
+
+    local state = self:CaptureGameState()
+    self:Print("=== Current Game State ===")
+    self:Print("Time: " .. state.time)
+    self:Print("Power: " .. state.power .. "/" .. state.powerMax)
+    self:Print("In Combat: " .. tostring(state.inCombat))
+    self:Print("Has Target: " .. tostring(state.hasTarget))
+    self:Print("GCD Remaining: " .. state.gcdRemaining)
+
+    if state.comboPoints > 0 then
+        self:Print("Combo Points: " .. state.comboPoints)
+    end
+
+    self:Print("Active Buffs: " .. self:CountTable(state.buffs))
+    self:Print("Active Debuffs: " .. self:CountTable(state.debuffs))
+    self:Print("=========================")
+end
+
+function TR:CountTable(t)
+    local count = 0
+    for _ in pairs(t) do count = count + 1 end
+    return count
+end
+
+-- ================= Slash Commands =================
+
+SLASH_TACOROTPRED1 = "/trpred"
+SlashCmdList["TACOROTPRED"] = function(msg)
+    msg = (msg or ""):lower()
+
+    if msg == "enable" then
+        TR.db.profile.prediction.enabled = true
+        TR:InitializePredictionSystem()
+        TR:Print("Enhanced prediction enabled")
+    elseif msg == "disable" then
+        TR.db.profile.prediction.enabled = false
+        TR:Print("Enhanced prediction disabled")
+    elseif msg == "stats" then
+        TR:Print(TR:GetPredictionStats())
+    elseif msg == "debug" then
+        TR:DumpGameState()
+    elseif msg == "clear" then
+        TR.PredictionCache = {}
+        TR:Print("Prediction cache cleared")
+    else
+        TR:Print("TacoRot Prediction Commands:")
+        TR:Print("/trpred enable|disable - Toggle prediction system")
+        TR:Print("/trpred stats - Show performance statistics") 
+        TR:Print("/trpred debug - Dump current game state")
+        TR:Print("/trpred clear - Clear prediction cache")
+    end
+end
+
+-- ================= Auto-Integration =================
+
+-- Automatically integrate with existing options if they exist
+if TR.OptionsRoot and TR.OptionsRoot.args then
+    TR:AddPredictionOptions(TR.OptionsRoot)
+end
+
+TR:Print("Enhanced prediction core integration loaded. Use /trpred for commands.")

--- a/engine_warlock.lua
+++ b/engine_warlock.lua
@@ -1,38 +1,38 @@
--- engine_warlock.lua — TacoRot Warlock (3.3.5)
--- Adds Buff padding (OOC) and Pets maintenance (where applicable) for new-player accessibility.
+-- engine_warlock.lua — TacoRot Warlock (3.3.5) - ENHANCED WITH PREDICTION
 
 local TR = _G.TacoRot
 if not TR then return end
 
--- Resolve IDS table
 local function ResolveIDS()
   local t
-  t = _G.TacoRot_IDS_Warlock;       if type(t)=="table" and (t.Ability or t.Rank) then return t end
-  t = _G.TacoRot_IDS_WARLOCK;       if type(t)=="table" and (t.Ability or t.Rank) then return t end
-  if type(_G.TacoRot_IDS)=="table" then
-    t = _G.TacoRot_IDS["WARLOCK"]; if type(t)=="table" and (t.Ability or t.Rank) then return t end
-    t = _G.TacoRot_IDS["Warlock"]; if type(t)=="table" and (t.Ability or t.Rank) then return t end
-    if _G.TacoRot_IDS.Ability then return _G.TacoRot_IDS end
-  end
+  t = _G.TacoRot_IDS_Warlock; if type(t)=="table" and (t.Ability or t.Rank) then return t end
+  t = _G.TacoRot_IDS_WARLOCK; if type(t)=="table" and (t.Ability or t.Rank) then return t end
+  t = _G.TacoRot_IDS; if type(t)=="table" and (t.Ability or t.Rank) then return t end
   return nil
 end
-
 local IDS = ResolveIDS() or {}; local A = IDS.Ability
-local SAFE = 686
+local SAFE = 686 -- Shadow Bolt
 
--- Spec name
 local function PrimaryTab() local n=(GetNumTalentTabs and GetNumTalentTabs()) or 3; local b,p=1,-1; for i=1,n do local _,_,pt=GetTalentTabInfo(i); pt=pt or 0; if pt>p then b,p=i,pt end end return b end
-local function SpecName() local tab=PrimaryTab(); return (tab==1 and "Affliction") or (tab==2 and "Demonology") or "Destruction" end
+local function SpecName() local tab=PrimaryTab(); if tab==1 then return "Affliction" elseif tab==2 then return "Demonology" else return "Destruction" end end
 
--- Config
 local TOKEN = "WARLOCK"
 local function Pad() local p=TR and TR.db and TR.db.profile and TR.db.profile.pad; local v=p and p[TOKEN]; if not v then return {enabled=true,gcd=1.6} end; if v.enabled==nil then v.enabled=true end; v.gcd=v.gcd or 1.6; return v end
 local function BuffCfg() local p=TR and TR.db and TR.db.profile and TR.db.profile.buff; return (p and p[TOKEN]) or {enabled=true} end
 local function PetCfg() local p=TR and TR.db and TR.db.profile and TR.db.profile.pet; return (p and p[TOKEN]) or {enabled=true} end
 
--- Helpers
+-- ================= Enhanced Helper Functions =================
+
 local function Known(id) return id and (IsPlayerSpell and IsPlayerSpell(id) or (IsSpellKnown and IsSpellKnown(id))) end
-local function ReadyNow(id) if not Known(id) then return false end local s,d,en = GetSpellCooldown(id); if en==0 then return false end return (not s or s==0 or d==0) end
+
+-- ORIGINAL ReadyNow/ReadySoon for fallback
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local s,d,en = GetSpellCooldown(id)
+  if en == 0 then return false end
+  return (not s or s==0 or d==0)
+end
+
 local function ReadySoon(id)
   local pad = Pad()
   if not pad.enabled then return ReadyNow(id) end
@@ -44,46 +44,134 @@ local function ReadySoon(id)
   local remaining = (start + duration) - GetTime()
   return remaining <= (pad.gcd + gcd)
 end
+
+-- ENHANCED prediction functions
+local function GetCurrentGameState()
+    return TR.CaptureGameState and TR:CaptureGameState() or {}
+end
+
+local function PredictiveReadySoon(id, futureState, timeOffset)
+    if TR.PredictiveReadySoon then
+        return TR.PredictiveReadySoon(id, futureState, timeOffset)
+    else
+        return ReadySoon(id) -- Fallback
+    end
+end
+
+local function StateHasDebuffID(state, debuffId)
+    if TR.StateHasDebuffID then
+        return TR:StateHasDebuffID(state, debuffId)
+    else
+        -- Fallback to current checking
+        return DebuffUpID("target", debuffId)
+    end
+end
+
+-- Original helper functions (preserved)
 local function DebuffUpID(u, id) if not id then return false end local wanted=GetSpellInfo(id) for i=1,40 do local name,_,_,_,_,_,_,caster,_,_,sid=UnitDebuff(u,i); if not name then break end if sid==id or (name==wanted and caster=="player") then return true end end return false end
 local function BuffUpID(u, id) if not id then return false end local wanted=GetSpellInfo(id); if not wanted then return false end for i=1,40 do local name,_,_,_,_,_,_,_,_,_,sid=UnitBuff(u,i); if not name then break end if sid==id or name==wanted then return true end end return false end
 local function HaveTarget() return UnitExists("target") and not UnitIsDead("target") end
 local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
 local function Push(q,id) if id then q[#q+1]=id end end
 
--- OOC Buffs
-
-local function FelArmorID()
-  if A and A.FelArmor then return A.FelArmor end
-  local r = 47893; if Known(r) then return r end -- Fel Armor
-  return nil
+-- Fallback safe
+local function Fallback()
+  return SAFE
 end
 
-local function DemonSkinID()
-  if A and A.DemonSkin then return A.DemonSkin end
-  local r = 687; if Known(r) then return r end -- Demon Skin (rank 1)
-  return nil
+-- ================= Enhanced Spell Prediction =================
+
+-- Warlock-specific spell prediction logic
+function TR:PredictNextSpell_Warlock(state, queue)
+    local A = (self.IDS and self.IDS.Ability) or {}
+    if not A then return nil end
+    
+    local tree = PrimaryTab()
+    
+    -- Priority 1: Essential DoTs if missing or expiring soon
+    if A.Corruption and not StateHasDebuffID(state, A.Corruption) and PredictiveReadySoon(A.Corruption, state) then
+        return A.Corruption
+    end
+    
+    if A.CurseOfAgony and not StateHasDebuffID(state, A.CurseOfAgony) and PredictiveReadySoon(A.CurseOfAgony, state) then
+        return A.CurseOfAgony
+    end
+    
+    -- Affliction-specific
+    if tree == 1 then
+        if A.UnstableAffliction and not StateHasDebuffID(state, A.UnstableAffliction) and PredictiveReadySoon(A.UnstableAffliction, state) then
+            return A.UnstableAffliction
+        end
+        if A.Haunt and not StateHasDebuffID(state, A.Haunt) and PredictiveReadySoon(A.Haunt, state) then
+            return A.Haunt
+        end
+    end
+    
+    -- Destruction-specific  
+    if tree == 3 then
+        if A.Immolate and not StateHasDebuffID(state, A.Immolate) and PredictiveReadySoon(A.Immolate, state) then
+            return A.Immolate
+        end
+        if A.Conflagrate and StateHasDebuffID(state, A.Immolate) and PredictiveReadySoon(A.Conflagrate, state) then
+            return A.Conflagrate
+        end
+        if A.ChaosBolt and PredictiveReadySoon(A.ChaosBolt, state) then
+            return A.ChaosBolt
+        end
+    end
+    
+    -- Filler spells
+    if A.ShadowBolt and PredictiveReadySoon(A.ShadowBolt, state) then
+        return A.ShadowBolt
+    end
+    
+    if A.Incinerate and PredictiveReadySoon(A.Incinerate, state) then
+        return A.Incinerate
+    end
+    
+    return nil
+end
+
+-- ================= OOC Buff Maintenance =================
+
+local function ArmorID()
+  if A and A.DemonArmor then return A.DemonArmor end
+  local da = 47793; if Known(da) then return da end
+  return 706
 end
 
 local function BuildBuffQueue()
   local cfg = BuffCfg(); if not (cfg.enabled ~= false) then return end
   local q = {}
+  local state = GetCurrentGameState()
   
-  -- Check if we have any armor buff at all first
-  local fa = FelArmorID()
-  local ds = DemonSkinID()
-  local hasArmorBuff = false
-  
-  if fa and BuffUpID("player", fa) then
-    hasArmorBuff = true
-  elseif ds and BuffUpID("player", ds) then
-    hasArmorBuff = true
+  if (cfg.armor ~= false) then
+    local armorId = ArmorID()
+    if armorId and not BuffUpID("player", armorId) and PredictiveReadySoon(armorId, state) then 
+      Push(q, armorId) 
+    end
   end
   
-  -- If no armor buff, prioritize: Fel Armor > Demon Skin
-  if not hasArmorBuff then
-    if fa and ReadySoon(fa) and (cfg.felArmor ~= false) then
+  -- Soul Link for Demonology
+  local tree = PrimaryTab()
+  if tree == 2 and A and A.SoulLink and (cfg.soulLink ~= false) then
+    if not BuffUpID("player", A.SoulLink) and PredictiveReadySoon(A.SoulLink, state) then 
+      Push(q, A.SoulLink) 
+    end
+  end
+  
+  -- Fel Armor for high-level warlocks
+  if (cfg.felArmor ~= false) then
+    local fa = A and A.FelArmor
+    if fa and Known(fa) and not BuffUpID("player", fa) and PredictiveReadySoon(fa, state) then
       Push(q, fa)
-    elseif ds and ReadySoon(ds) and (cfg.demonSkin ~= false) then
+    end
+  end
+  
+  -- Demon Skin for low levels
+  if (cfg.demonSkin ~= false) then
+    local ds = A and A.DemonSkin
+    if ds and not BuffUpID("player", ds) and PredictiveReadySoon(ds, state) then
       Push(q, ds)
     end
   end
@@ -91,22 +179,28 @@ local function BuildBuffQueue()
   return q
 end
 
-
--- Pets
+-- ================= Pet Management =================
 
 local function KnownFirst(...)
   for i=1, select("#", ...) do local id = select(i, ...); if id and Known(id) then return id end end
 end
 
 local function BestDemon()
-  -- For low levels, prioritize Imp if it's the only one available
   local felguard = (A and A.SummonFelguard) or 30146
-  local felhunter = (A and A.SummonFelhunter) or 691
+  local felhunter = (A and A.SummonFelhunter) or 691  
+  local succubus = (A and A.SummonSuccubus) or 712
   local voidwalker = (A and A.SummonVoidwalker) or 697
   local imp = (A and A.SummonImp) or 688
   
-  -- Check what we actually know and prefer higher level demons
-  return KnownFirst(felguard, felhunter, voidwalker, imp)
+  -- Prefer based on spec
+  local tree = PrimaryTab()
+  if tree == 2 then -- Demonology
+    return KnownFirst(felguard, felhunter, voidwalker, imp)
+  elseif tree == 3 then -- Destruction
+    return KnownFirst(imp, succubus, felhunter, voidwalker)
+  else -- Affliction
+    return KnownFirst(felhunter, voidwalker, imp, succubus)
+  end
 end
 
 local function HasPet() return UnitExists("pet") and not UnitIsDead("pet") end
@@ -114,63 +208,122 @@ local function HasPet() return UnitExists("pet") and not UnitIsDead("pet") end
 local function BuildPetQueue()
   local cfg = PetCfg(); if not (cfg.enabled ~= false and (cfg.summon ~= false)) then return end
   local q = {}
+  local state = GetCurrentGameState()
+  
   if not HasPet() then
     local demon = BestDemon()
-    if demon and ReadySoon(demon) then Push(q, demon) end
+    if demon and PredictiveReadySoon(demon, state) then 
+      Push(q, demon) 
+    end
   end
   return q
 end
 
+-- ================= Enhanced DPS Priorities =================
 
--- DPS Priorities (existing style, trimmed)
+local function BuildPredictiveQueue_Warlock(originalQueue, state)
+    if TR.BuildPredictiveQueue then
+        return TR:BuildPredictiveQueue(originalQueue, 6) -- Look 6 spells ahead
+    else
+        return originalQueue -- Fallback to original
+    end
+end
 
 local function BuildQueue()
   local q = {}
+  local state = GetCurrentGameState()
   local tree = PrimaryTab()
+  
+  -- Use enhanced prediction functions
+  local useEnhanced = TR.db and TR.db.profile and TR.db.profile.prediction and TR.db.profile.prediction.enabled
+  local ReadyFunc = useEnhanced and PredictiveReadySoon or ReadySoon
+  local HasDebuffFunc = useEnhanced and StateHasDebuffID or 
+    function(state, id) return DebuffUpID("target", id) end
 
-  if A.Corruption and not DebuffUpID("target", A.Corruption) and ReadySoon(A.Corruption) then Push(q, A.Corruption) end
-  if A.CurseOfAgony and not DebuffUpID("target", A.CurseOfAgony) and ReadySoon(A.CurseOfAgony) then Push(q, A.CurseOfAgony) end
-
-  if A.UnstableAffliction and not DebuffUpID("target", A.UnstableAffliction) and ReadySoon(A.UnstableAffliction) then
-    Push(q, A.UnstableAffliction)
+  -- Core DoT priority
+  if A.Corruption and not HasDebuffFunc(state, A.Corruption) and ReadyFunc(A.Corruption, state) then 
+    Push(q, A.Corruption) 
+  end
+  
+  if A.CurseOfAgony and not HasDebuffFunc(state, A.CurseOfAgony) and ReadyFunc(A.CurseOfAgony, state) then 
+    Push(q, A.CurseOfAgony) 
   end
 
-  if tree == 3 then
-    if A.Immolate and not DebuffUpID("target", A.Immolate) and ReadySoon(A.Immolate) then Push(q, A.Immolate) end
-    if A.Conflagrate and DebuffUpID("target", A.Immolate) and ReadySoon(A.Conflagrate) then Push(q, A.Conflagrate) end
+  -- Spec-specific priorities
+  if tree == 1 then -- Affliction
+    if A.UnstableAffliction and not HasDebuffFunc(state, A.UnstableAffliction) and ReadyFunc(A.UnstableAffliction, state) then
+      Push(q, A.UnstableAffliction)
+    end
+    if A.Haunt and not HasDebuffFunc(state, A.Haunt) and ReadyFunc(A.Haunt, state) then
+      Push(q, A.Haunt)
+    end
+    if A.DrainSoul and ReadyFunc(A.DrainSoul, state) then
+      -- Use drain soul at low target health
+      if HaveTarget() and (UnitHealth("target") / UnitHealthMax("target")) <= 0.25 then
+        Push(q, A.DrainSoul)
+      end
+    end
+  elseif tree == 2 then -- Demonology  
+    if A.Metamorphosis and ReadyFunc(A.Metamorphosis, state) then
+      Push(q, A.Metamorphosis)
+    end
+    if A.SoulFire and ReadyFunc(A.SoulFire, state) then
+      Push(q, A.SoulFire)
+    end
+  else -- Destruction
+    if A.Immolate and not HasDebuffFunc(state, A.Immolate) and ReadyFunc(A.Immolate, state) then 
+      Push(q, A.Immolate) 
+    end
+    if A.Conflagrate and HasDebuffFunc(state, A.Immolate) and ReadyFunc(A.Conflagrate, state) then 
+      Push(q, A.Conflagrate) 
+    end
+    if A.ChaosBolt and ReadyFunc(A.ChaosBolt, state) then
+      Push(q, A.ChaosBolt)
+    end
+    if A.Incinerate and ReadyFunc(A.Incinerate, state) then
+      Push(q, A.Incinerate)
+    end
   end
 
-  if A.ShadowBolt and ReadySoon(A.ShadowBolt) then Push(q, A.ShadowBolt) end
-
-  if UnitPower("player", 0) / UnitPowerMax("player", 0) < 0.2 and A.LifeTap and ReadySoon(A.LifeTap) then
-    Push(q, A.LifeTap)
+  -- Filler spells
+  if A.ShadowBolt and ReadyFunc(A.ShadowBolt, state) then 
+    Push(q, A.ShadowBolt) 
   end
 
-  return q
+  -- Life Tap for mana management
+  if A.LifeTap and ReadyFunc(A.LifeTap, state) then
+    local manaPercent = UnitPower("player", 0) / UnitPowerMax("player", 0)
+    if manaPercent < 0.3 then -- Low mana
+      Push(q, A.LifeTap)
+    end
+  end
+  
+  -- Use enhanced prediction if available
+  if useEnhanced then
+    return BuildPredictiveQueue_Warlock(q, state)
+  else
+    return pad3(q, Fallback())
+  end
 end
 
+-- ================= Enhanced Engine Tick =================
 
 function TR:EngineTick_Warlock()
   IDS = ResolveIDS() or IDS
   A = (IDS and IDS.Ability) or A
   if IDS and IDS.UpdateRanks then pcall(IDS.UpdateRanks, IDS) end
 
-  local q = {}
+  local q
   if not A or not next(A) then
     q = {SAFE,SAFE,SAFE}
   elseif not UnitAffectingCombat("player") then
-    -- Out of combat: prioritize pets, then buffs
-    local petQ = BuildPetQueue()
-    local buffQ = BuildBuffQueue()
-    
-    if petQ and petQ[1] then
-      q = petQ
-    elseif buffQ and buffQ[1] then
-      q = buffQ
-    elseif HaveTarget() then
-      q = BuildQueue()
-    else
-      q = {SAFE,SAFE,SAFE}
+    q = BuildPetQueue() or BuildBuffQueue() or {}
+    if not q[1] then
+      if HaveTarget() then 
+        q = BuildQueue() 
+      else 
+        q = {SAFE,SAFE,SAFE} 
+      end
     end
   else
     q = BuildQueue()
@@ -179,34 +332,81 @@ function TR:EngineTick_Warlock()
   q = pad3(q or {}, SAFE)
   self._lastMainSpell = q[1]
   
-  -- Fix UI update call
-  if TR.UI_Update then
-    TR.UI_Update(q[1], q[2], q[3])
-  elseif self.UI and self.UI.Update then 
+  -- Enhanced UI update with prediction info
+  if self.UI and self.UI.Update then 
     self.UI:Update(q[1], q[2], q[3]) 
   end
+  
+  -- Debug output if enabled
+  if self.db and self.db.profile.prediction and self.db.profile.prediction.debugMode then
+    if q[1] ~= self._lastDebugSpell then
+      local spellName = GetSpellInfo(q[1]) or "Unknown"
+      self:DebugPrediction("Next: " .. spellName .. " (" .. (q[1] or "nil") .. ")")
+      self._lastDebugSpell = q[1]
+    end
+  end
 end
+
+-- ================= Enhanced Start/Stop Functions =================
 
 function TR:StartEngine_Warlock()
   self:StopEngine_Warlock()
   self:EngineTick_Warlock()
+  
+  local useEnhanced = self.db and self.db.profile and self.db.profile.prediction and self.db.profile.prediction.enabled
   local AceTimer = LibStub and LibStub("AceTimer-3.0", true)
+  
   if AceTimer and AceTimer.ScheduleRepeatingTimer then
-    self._engineTimer_WA = AceTimer:ScheduleRepeatingTimer(function() _G.TacoRot:EngineTick_Warlock() end, 0.20)
+    if useEnhanced then
+      -- Dynamic timer system
+      local function DynamicTick()
+        local interval = self:GetOptimalUpdateInterval and self:GetOptimalUpdateInterval() or 0.1
+        self:EngineTick_Warlock()
+        
+        if self._engineTimer_WL then
+          self._engineTimer_WL = AceTimer:ScheduleTimer(DynamicTick, interval)
+        end
+      end
+      self._engineTimer_WL = AceTimer:ScheduleTimer(DynamicTick, 0.1)
+    else
+      -- Standard fixed timer
+      self._engineTimer_WL = AceTimer:ScheduleRepeatingTimer(function() _G.TacoRot:EngineTick_Warlock() end, 0.20)
+    end
   else
+    -- Fallback frame-based timer
     local acc, f = 0, CreateFrame("Frame")
-    f:SetScript("OnUpdate", function(_, e) acc=acc+(e or 0); if acc>=0.20 then acc=acc-0.20; _G.TacoRot:EngineTick_Warlock() end end)
-    self._engineTimer_WA = f
+    f:SetScript("OnUpdate", function(_, elapsed)
+      acc = acc + (elapsed or 0)
+      local targetInterval = useEnhanced and (self:GetOptimalUpdateInterval and self:GetOptimalUpdateInterval() or 0.1) or 0.20
+      
+      if acc >= targetInterval then
+        acc = acc - targetInterval
+        _G.TacoRot:EngineTick_Warlock()
+      end
+    end)
+    self._engineTimer_WL = f
   end
-  self:Print("TacoRot Warlock engine active: " .. SpecName())
+  
+  local engineType = useEnhanced and " enhanced engine" or " engine"
+  self:Print("TacoRot Warlock" .. engineType .. " active: " .. SpecName())
 end
 
 function TR:StopEngine_Warlock()
-  local t = self._engineTimer_WA
+  local t = self._engineTimer_WL
   if not t then return end
   local AceTimer = LibStub and LibStub("AceTimer-3.0", true)
-  if AceTimer and type(t)=="number" then AceTimer:CancelTimer(t,true) elseif type(t)=="table" and t.SetScript then t:SetScript("OnUpdate",nil); t:Hide() end
-  self._engineTimer_WA = nil
+  if AceTimer and type(t)=="number" then 
+    AceTimer:CancelTimer(t,true) 
+  elseif type(t)=="table" and t.SetScript then 
+    t:SetScript("OnUpdate",nil); t:Hide() 
+  end
+  self._engineTimer_WL = nil
 end
 
-do local _,c=UnitClass("player"); if c=="WARLOCK" then TR:StartEngine_Warlock() end end
+-- Auto-start for Warlock class
+do 
+  local _, c = UnitClass("player")
+  if c == "WARLOCK" then 
+    TR:StartEngine_Warlock() 
+  end 
+end

--- a/prediction_engine.lua
+++ b/prediction_engine.lua
@@ -1,0 +1,367 @@
+local TR = _G.TacoRot or {}
+
+-- ================= Enhanced Prediction System =================
+
+-- State simulation cache to avoid recalculating
+TR.PredictionCache = TR.PredictionCache or {}
+TR.LastGameState = TR.LastGameState or {}
+
+-- Enhanced game state tracking
+local function CaptureGameState()
+    local state = {
+        time = GetTime(),
+        power = UnitPower("player"),
+        powerMax = UnitPowerMax("player"),
+        powerType = UnitPowerType("player"),
+        health = UnitHealth("player"),
+        healthMax = UnitHealthMax("player"),
+        level = UnitLevel("player"),
+        inCombat = UnitAffectingCombat("player"),
+        hasTarget = UnitExists("target") and not UnitIsDead("target"),
+        targetHealth = UnitExists("target") and UnitHealth("target") or 0,
+        targetHealthMax = UnitExists("target") and UnitHealthMax("target") or 1,
+        isMoving = GetUnitSpeed("player") > 0,
+        isCasting = UnitCastingInfo("player") ~= nil or UnitChannelInfo("player") ~= nil,
+        gcdRemaining = 0, -- Will be calculated
+        buffs = {},
+        debuffs = {},
+        cooldowns = {},
+        comboPoints = GetComboPoints and GetComboPoints("player", "target") or 0,
+        runes = {}, -- For DK
+        energy = UnitPowerType("player") == 3 and UnitPower("player") or 0,
+        rage = UnitPowerType("player") == 1 and UnitPower("player") or 0,
+        mana = UnitPowerType("player") == 0 and UnitPower("player") or 0,
+    }
+
+    -- Calculate GCD remaining
+    local gcdStart, gcdDuration = GetSpellCooldown(61304) -- GCD spell ID
+    if gcdStart and gcdStart > 0 and gcdDuration and gcdDuration > 0 then
+        state.gcdRemaining = math.max(0, (gcdStart + gcdDuration) - GetTime())
+    end
+
+    -- Capture buffs (player)
+    for i = 1, 40 do
+        local name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId = UnitBuff("player", i)
+        if not name then break end
+        state.buffs[spellId or name] = {
+            name = name,
+            count = count or 1,
+            duration = duration or 0,
+            expirationTime = expirationTime or 0,
+            remaining = expirationTime and (expirationTime - GetTime()) or 0,
+            spellId = spellId
+        }
+    end
+
+    -- Capture debuffs (target)
+    if state.hasTarget then
+        for i = 1, 40 do
+            local name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId = UnitDebuff("target", i)
+            if not name then break end
+            if source == "player" then
+                state.debuffs[spellId or name] = {
+                    name = name,
+                    count = count or 1,
+                    duration = duration or 0,
+                    expirationTime = expirationTime or 0,
+                    remaining = expirationTime and (expirationTime - GetTime()) or 0,
+                    spellId = spellId
+                }
+            end
+        end
+    end
+
+    return state
+end
+
+-- Simulate casting a spell and predict the resulting game state
+local function SimulateSpellCast(currentState, spellId, castTime)
+    if not spellId or not currentState then return currentState end
+
+    -- Create a copy of current state
+    local newState = {}
+    for k, v in pairs(currentState) do
+        if type(v) == "table" then
+            newState[k] = {}
+            for k2, v2 in pairs(v) do
+                if type(v2) == "table" then
+                    newState[k][k2] = {}
+                    for k3, v3 in pairs(v2) do newState[k][k2][k3] = v3 end
+                else
+                    newState[k][k2] = v2
+                end
+            end
+        else
+            newState[k] = v
+        end
+    end
+
+    castTime = castTime or 0
+    newState.time = newState.time + castTime
+
+    -- Get spell info
+    local spellName, _, _, _, _, _, spellCastTime, _, _ = GetSpellInfo(spellId)
+    if not spellName then return newState end
+
+    spellCastTime = (spellCastTime or 0) / 1000
+    local actualCastTime = math.max(spellCastTime, 1.5) -- Minimum GCD
+
+    -- Simulate resource changes based on spell
+    local powerCost = GetSpellPowerCost(spellId)
+    if powerCost and powerCost[1] then
+        local cost = powerCost[1].cost or 0
+        local powerType = powerCost[1].type
+
+        if powerType == 0 then -- Mana
+            newState.mana = math.max(0, newState.mana - cost)
+        elseif powerType == 1 then -- Rage
+            newState.rage = math.max(0, newState.rage - cost)
+        elseif powerType == 3 then -- Energy
+            newState.energy = math.max(0, newState.energy - cost)
+        end
+    end
+
+    -- Simulate resource regeneration during cast time
+    if newState.energy > 0 then
+        newState.energy = math.min(100, newState.energy + (actualCastTime * 10)) -- 10 energy/sec
+    end
+    if newState.rage > 0 and newState.inCombat then
+        newState.rage = math.min(100, newState.rage + (actualCastTime * 2)) -- 2 rage/sec in combat
+    end
+
+    -- Update time-based effects (buffs/debuffs decay)
+    for id, buff in pairs(newState.buffs) do
+        if buff.remaining > 0 then
+            buff.remaining = math.max(0, buff.remaining - actualCastTime)
+            if buff.remaining <= 0 then
+                newState.buffs[id] = nil
+            end
+        end
+    end
+
+    for id, debuff in pairs(newState.debuffs) do
+        if debuff.remaining > 0 then
+            debuff.remaining = math.max(0, debuff.remaining - actualCastTime)
+            if debuff.remaining <= 0 then
+                newState.debuffs[id] = nil
+            end
+        end
+    end
+
+    -- Update cooldowns
+    for id, cooldown in pairs(newState.cooldowns) do
+        cooldown.remaining = math.max(0, cooldown.remaining - actualCastTime)
+    end
+
+    -- Set spell on cooldown
+    local cooldownStart, cooldownDuration = GetSpellCooldown(spellId)
+    if cooldownDuration and cooldownDuration > 0 then
+        newState.cooldowns[spellId] = {
+            remaining = cooldownDuration,
+            duration = cooldownDuration
+        }
+    end
+
+    -- Simulate specific spell effects (you'll want to expand this per spell)
+    newState = SimulateSpellEffects(newState, spellId, spellName)
+
+    return newState
+end
+
+-- Simulate specific spell effects (expand this for each class/spell)
+function SimulateSpellEffects(state, spellId, spellName)
+    -- Example implementations - expand based on your class engines
+
+    -- Combo point generators
+    local comboGenerators = {
+        [1752] = 1, -- Sinister Strike
+        [48691] = 2, -- Mutilate
+        [48654] = 1, -- Hemorrhage
+    }
+
+    if comboGenerators[spellId] then
+        state.comboPoints = math.min(5, state.comboPoints + comboGenerators[spellId])
+    end
+
+    -- Combo point finishers
+    local comboFinishers = {
+        [48668] = true, -- Eviscerate
+        [57993] = true, -- Envenom
+    }
+
+    if comboFinishers[spellId] then
+        state.comboPoints = 0
+    end
+
+    -- DoT applications (simplified)
+    local dots = {
+        [48672] = {duration = 18, id = 48672}, -- Rupture
+        [26688] = {duration = 21, id = 26688}, -- Anesthetic Poison
+    }
+
+    if dots[spellId] then
+        state.debuffs[spellId] = {
+            name = spellName,
+            remaining = dots[spellId].duration,
+            duration = dots[spellId].duration,
+            spellId = spellId
+        }
+    end
+
+    return state
+end
+
+-- Enhanced ReadySoon that considers predicted state
+local function PredictiveReadySoon(spellId, futureState, timeOffset)
+    timeOffset = timeOffset or 0
+    futureState = futureState or CaptureGameState()
+
+    if not spellId then return false end
+
+    -- Check if spell is known
+    if not (IsPlayerSpell and IsPlayerSpell(spellId) or (IsSpellKnown and IsSpellKnown(spellId))) then
+        return false
+    end
+
+    -- Check cooldown in future state
+    local cooldown = futureState.cooldowns[spellId]
+    if cooldown and cooldown.remaining > timeOffset then
+        return false
+    end
+
+    -- Check GCD
+    if futureState.gcdRemaining > timeOffset then
+        return false
+    end
+
+    -- Check resource costs
+    local powerCost = GetSpellPowerCost(spellId)
+    if powerCost and powerCost[1] then
+        local cost = powerCost[1].cost or 0
+        local powerType = powerCost[1].type
+
+        if powerType == 0 and futureState.mana < cost then return false end
+        if powerType == 1 and futureState.rage < cost then return false end
+        if powerType == 3 and futureState.energy < cost then return false end
+    end
+
+    return true
+end
+
+-- Enhanced queue building with prediction
+function TR:BuildPredictiveQueue(baseQueue, maxDepth)
+    maxDepth = maxDepth or 6
+    local currentState = CaptureGameState()
+    local queue = {}
+    local workingState = currentState
+
+    -- Start with base queue or build from scratch
+    if baseQueue and baseQueue[1] then
+        table.insert(queue, baseQueue[1])
+        workingState = SimulateSpellCast(workingState, baseQueue[1])
+    end
+
+    -- Predict future spells
+    for depth = #queue + 1, maxDepth do
+        local nextSpell = self:PredictNextSpell(workingState, queue)
+        if nextSpell and PredictiveReadySoon(nextSpell, workingState) then
+            table.insert(queue, nextSpell)
+            workingState = SimulateSpellCast(workingState, nextSpell)
+        else
+            break
+        end
+    end
+
+    return queue
+end
+
+-- Predict the next optimal spell based on current state and priority
+function TR:PredictNextSpell(gameState, currentQueue)
+    -- This should be implemented per class
+    -- For now, return a basic priority based on your existing BuildQueue logic
+
+    -- Example for rogue (you'll need to implement this for each class)
+    local _, class = UnitClass("player")
+    if class == "ROGUE" then
+        return self:PredictNextSpell_Rogue(gameState, currentQueue)
+    elseif class == "MAGE" then
+        return self:PredictNextSpell_Mage(gameState, currentQueue)
+    -- Add other classes...
+    end
+
+    return nil
+end
+
+-- Example implementation for Rogue
+function TR:PredictNextSpell_Rogue(state, queue)
+    local A = (self.IDS and self.IDS.Ability) or {}
+
+    -- Simplified rogue priority with state consideration
+    if state.comboPoints >= 4 and A.Eviscerate and PredictiveReadySoon(A.Eviscerate, state) then
+        return A.Eviscerate
+    end
+
+    if state.comboPoints < 5 and A.Mutilate and PredictiveReadySoon(A.Mutilate, state) then
+        return A.Mutilate
+    end
+
+    if state.comboPoints < 5 and A.SinisterStrike and PredictiveReadySoon(A.SinisterStrike, state) then
+        return A.SinisterStrike
+    end
+
+    return nil
+end
+
+-- Enhanced update frequency based on game events
+function TR:UpdatePredictionEngine()
+    -- Increase update frequency during active gameplay
+    local now = GetTime()
+    local timeSinceLastCast = now - (self.lastCastTime or 0)
+    local updateInterval = 0.1 -- Default to 100ms for smoother updates
+
+    -- Reduce frequency when not much is happening
+    if not UnitAffectingCombat("player") and timeSinceLastCast > 5 then
+        updateInterval = 0.5 -- 500ms when idle
+    elseif self.isChanneling or UnitCastingInfo("player") then
+        updateInterval = 0.05 -- 50ms during casting for precise updates
+    end
+
+    return updateInterval
+end
+
+-- Integration function to replace your existing ReadySoon in engines
+function TR:GetEnhancedReadySoon()
+    return PredictiveReadySoon
+end
+
+-- Cache invalidation for performance
+function TR:InvalidatePredictionCache()
+    self.PredictionCache = {}
+end
+
+-- Event handlers for real-time updates
+function TR:RegisterPredictionEvents()
+    self:RegisterEvent("SPELL_UPDATE_COOLDOWN", "InvalidatePredictionCache")
+    self:RegisterEvent("UNIT_POWER_FREQUENT", "InvalidatePredictionCache") 
+    self:RegisterEvent("UNIT_AURA", "InvalidatePredictionCache")
+    self:RegisterEvent("PLAYER_TARGET_CHANGED", "InvalidatePredictionCache")
+    self:RegisterEvent("UNIT_COMBO_POINTS", "InvalidatePredictionCache")
+end
+
+-- Enhanced state checking functions for your engines
+function TR:StateHasBuffID(state, buffId)
+    return state.buffs[buffId] and state.buffs[buffId].remaining > 0
+end
+
+function TR:StateHasDebuffID(state, debuffId)
+    return state.debuffs[debuffId] and state.debuffs[debuffId].remaining > 0
+end
+
+function TR:StateSpellReady(state, spellId, timeOffset)
+    return PredictiveReadySoon(spellId, state, timeOffset or 0)
+end
+
+-- Export functions for backward compatibility
+TR.CaptureGameState = CaptureGameState
+TR.SimulateSpellCast = SimulateSpellCast
+TR.PredictiveReadySoon = PredictiveReadySoon


### PR DESCRIPTION
## Summary
- add core prediction system with game state capture and spell simulation
- integrate prediction into core startup and options
- upgrade warlock engine to use predictive queue and dynamic timers

## Testing
- `luac -v` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aff059048330be0f8b5496a5ec10