### PR TITLE
Show rotations even without a target

### DIFF
--- a/engine_paladin.lua
+++ b/engine_paladin.lua
@@ -120,7 +120,7 @@ function TR:EngineTick_Paladin()
   elseif not UnitAffectingCombat("player") then
     q = BuildBuffQueue() or {}
     if not q[1] then
-      if HaveTarget() then q = BuildQueue() else local fb = Fallback(); q = {fb,fb,fb} end
+      q = BuildQueue() -- Always show rotation, regardless of target
     end
   else
     q = BuildQueue()

--- a/engine_priest.lua
+++ b/engine_priest.lua
@@ -105,7 +105,7 @@ function TR:EngineTick_Priest()
   elseif not UnitAffectingCombat("player") then
     q = BuildBuffQueue() or {}
     if not q[1] then
-      if HaveTarget() then q = BuildQueue() else local fb = Fallback(); q = {fb,fb,fb} end
+      q = BuildQueue() -- Always show rotation, regardless of target
     end
   else
     q = BuildQueue()

--- a/engine_shaman.lua
+++ b/engine_shaman.lua
@@ -124,7 +124,7 @@ function TR:EngineTick_Shaman()
   elseif not UnitAffectingCombat("player") then
     q = BuildBuffQueue() or {}
     if not q[1] then
-      if HaveTarget() then q = BuildQueue() else local fb = Fallback(); q = {fb,fb,fb} end
+      q = BuildQueue() -- Always show rotation, regardless of target
     end
   else
     q = BuildQueue()

--- a/engine_warlock.lua
+++ b/engine_warlock.lua
@@ -173,18 +173,16 @@ function TR:EngineTick_Warlock()
   if not A or not next(A) then
     q = {SAFE,SAFE,SAFE}
   elseif not UnitAffectingCombat("player") then
-    -- Out of combat: prioritize pets, then buffs
+    -- Out of combat: prioritize pets, then buffs, then always show rotation
     local petQ = BuildPetQueue()
     local buffQ = BuildBuffQueue()
-    
+
     if petQ and petQ[1] then
       q = petQ
     elseif buffQ and buffQ[1] then
       q = buffQ
-    elseif HaveTarget() then
-      q = BuildQueue()
     else
-      q = {SAFE,SAFE,SAFE}
+      q = BuildQueue() -- Always show rotation, regardless of target
     end
   else
     q = BuildQueue()

--- a/engine_warrior.lua
+++ b/engine_warrior.lua
@@ -119,7 +119,7 @@ function TR:EngineTick_Warrior()
   elseif not UnitAffectingCombat("player") then
     q = BuildBuffQueue() or {}
     if not q[1] then
-      if HaveTarget() then q = BuildQueue() else local fb = Fallback(); q = {fb,fb,fb} end
+      q = BuildQueue() -- Always show rotation, regardless of target
     end
   else
     q = BuildQueue()


### PR DESCRIPTION
## Summary
- Always build rotation queues out of combat even when no target exists
- Let the Hunter engine continue building rotations without a target

## Testing
- `luac -p engine_warlock.lua engine_priest.lua engine_paladin.lua engine_shaman.lua engine_warrior.lua engine_hunter.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ab2f07948330842b8843319f5b32